### PR TITLE
Integrate ORCID search

### DIFF
--- a/frontend-RCEI/src/services/orcid.ts
+++ b/frontend-RCEI/src/services/orcid.ts
@@ -1,0 +1,14 @@
+export async function searchResearchers(query: string) {
+  const response = await fetch(
+    `https://pub.orcid.org/v3.0/expanded-search/?q=${encodeURIComponent(query)}`,
+    {
+      headers: { Accept: "application/json" },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch researchers');
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add ORCID search service
- fetch results with React Query in search page
- render API results and show skeletons while loading

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855844e5a8483219d02acca6b16c6fc