### PR TITLE
Handle search query param and add test

### DIFF
--- a/frontend-RCEI/package.json
+++ b/frontend-RCEI/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -83,6 +84,9 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^1.5.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2"
   }
 }

--- a/frontend-RCEI/src/pages/Search.tsx
+++ b/frontend-RCEI/src/pages/Search.tsx
@@ -1,5 +1,5 @@
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { searchResearchers } from "@/services/orcid";
 import { RceiLayout } from "@/components/RceiLayout";
@@ -13,11 +13,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Search as SearchIcon, BookOpen, User, Book } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useSearchParams } from "react-router-dom";
 
 
 const Search = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [filter, setFilter] = useState("all");
+  const [searchParams] = useSearchParams();
+  const [shouldFetch, setShouldFetch] = useState(false);
 
   const {
     data,
@@ -27,8 +30,16 @@ const Search = () => {
   } = useQuery({
     queryKey: ["search", searchQuery],
     queryFn: () => searchResearchers(searchQuery),
-    enabled: false,
+    enabled: shouldFetch && !!searchQuery,
   });
+
+  useEffect(() => {
+    const q = searchParams.get("q");
+    if (q) {
+      setSearchQuery(q);
+      setShouldFetch(true);
+    }
+  }, [searchParams]);
 
   const results = (data as any)?.["expanded-result"] ?? [];
   const publications = results.flatMap((r: any) => {
@@ -43,6 +54,7 @@ const Search = () => {
   const handleSearch = (e: FormEvent) => {
     e.preventDefault();
     if (searchQuery.trim()) {
+      setShouldFetch(true);
       refetch();
     }
   };

--- a/frontend-RCEI/src/pages/__tests__/Search.test.tsx
+++ b/frontend-RCEI/src/pages/__tests__/Search.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Search from '../Search';
+import * as orcidService from '../../services/orcid';
+
+vi.mock('../../services/orcid');
+
+describe('Search page', () => {
+  it('loads results from query param', async () => {
+    (orcidService.searchResearchers as unknown as vi.Mock).mockResolvedValueOnce({
+      "expanded-result": [
+        { "orcid-id": "1", "given-names": "John", "family-names": "Doe" }
+      ]
+    });
+
+    const client = new QueryClient();
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/search?q=example']}>
+          <Routes>
+            <Route path="/search" element={<Search />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await screen.findByText('John Doe');
+    expect(orcidService.searchResearchers).toHaveBeenCalledWith('example');
+  });
+});

--- a/frontend-RCEI/src/setupTests.ts
+++ b/frontend-RCEI/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend-RCEI/vite.config.ts
+++ b/frontend-RCEI/vite.config.ts
@@ -21,4 +21,9 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/setupTests.ts",
+    globals: true,
+  },
 }));


### PR DESCRIPTION
## Summary
- use `useSearchParams` to read the initial `q` query parameter
- trigger search automatically when the parameter is present
- keep search input synced with state
- configure vitest and add regression test for loading results via `/search?q=`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855901c91908321a2f1b592af6e6ac6