### PR TITLE
Implement ORCID login redirect

### DIFF
--- a/frontend-RCEI/.env.example
+++ b/frontend-RCEI/.env.example
@@ -1,2 +1,2 @@
 VITE_ORCID_CLIENT_ID=11bd8862-a4b3-4ab0-a1ab-ee086e82e5d0
-VITE_ORCID_REDIRECT_URI=http://localhost:8080/auth/callbac
+VITE_ORCID_REDIRECT_URI=http://localhost:8080/auth/callback

--- a/frontend-RCEI/src/.env
+++ b/frontend-RCEI/src/.env
@@ -1,1 +1,2 @@
 VITE_ORCID_CLIENT_ID=11bd8862-a4b3-4ab0-a1ab-ee086e82e5d0
+VITE_ORCID_REDIRECT_URI=http://localhost:8080/auth/callback

--- a/frontend-RCEI/src/pages/Login.tsx
+++ b/frontend-RCEI/src/pages/Login.tsx
@@ -5,6 +5,8 @@ import { LogIn, UserPlus } from "lucide-react";
 import { motion } from "framer-motion";
 import { useNavigate, Link } from "react-router-dom";
 
+const { VITE_ORCID_CLIENT_ID, VITE_ORCID_REDIRECT_URI } = import.meta.env;
+
 export default function LoginPage() {
     const navigate = useNavigate();  // Hook para navegação
     const [formData, setFormData] = useState({
@@ -97,7 +99,10 @@ export default function LoginPage() {
                                 <Button
                                     className="w-full bg-green-500 hover:bg-green-600 text-white font-medium py-2 rounded-xl"
                                     onClick={() => {
-                                        // Ação de login com ORCID (aqui você pode adicionar a lógica de ORCID)
+                                        const url =
+                                            `https://orcid.org/oauth/authorize?client_id=${VITE_ORCID_CLIENT_ID}` +
+                                            `&response_type=token&scope=/read-public&redirect_uri=${encodeURIComponent(VITE_ORCID_REDIRECT_URI)}`;
+                                        window.location.href = url;
                                     }}
                                 >
                                     <LogIn className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- read ORCID client id and redirect URI from environment
- wire up login button to start ORCID OAuth flow
- update example env files

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ab3a7af08321813480d72f2c93e1