### PR TITLE
Use auth context login

### DIFF
--- a/frontend-RCEI/src/pages/Login.tsx
+++ b/frontend-RCEI/src/pages/Login.tsx
@@ -4,9 +4,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { LogIn, UserPlus } from "lucide-react";
 import { motion } from "framer-motion";
 import { useNavigate, Link } from "react-router-dom";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function LoginPage() {
     const navigate = useNavigate();  // Hook para navegação
+    const { login } = useAuth();
     const [formData, setFormData] = useState({
         email: "",
         senha: "",
@@ -43,7 +45,7 @@ export default function LoginPage() {
             if (response.ok) {
                 // Sucesso no login
                 alert(`Login realizado com sucesso para: ${formData.email}`);
-                localStorage.setItem('token', result.token);  // Armazenando o token no localStorage
+                login(result.token);
 
                 // Redirecionar para o dashboard
                 navigate("/dashboard");


### PR DESCRIPTION
## Summary
- use `useAuth` in login page
- call the context `login()` method instead of directly using `localStorage`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ab656b388321965cf392796837fc