### PR TITLE
Handle ORCID callback via backend

### DIFF
--- a/frontend-RCEI/src/pages/AuthCallback.tsx
+++ b/frontend-RCEI/src/pages/AuthCallback.tsx
@@ -9,11 +9,43 @@ export default function AuthCallback() {
     useEffect(() => {
         const hash = window.location.hash.substring(1);
         const params = new URLSearchParams(hash);
-        const token = params.get("access_token");
-        if (token) {
-            login(token);
+        const orcidToken = params.get("access_token");
+        const orcidId = params.get("orcid");
+
+        async function authenticate() {
+            if (!orcidToken || !orcidId) {
+                navigate("/login");
+                return;
+            }
+
+            try {
+                const res = await fetch("http://localhost:5000/api/auth/orcid", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        orcidId,
+                        orcidToken,
+                    }),
+                });
+
+                const data = await res.json();
+
+                if (res.ok) {
+                    login(data.token);
+                    navigate("/dashboard");
+                } else {
+                    console.error(data.error);
+                    navigate("/login");
+                }
+            } catch (error) {
+                console.error("Erro ao autenticar via ORCID:", error);
+                navigate("/login");
+            }
         }
-        navigate("/dashboard");
+
+        authenticate();
     }, [navigate, login]);
 
     return <div className="p-4">Autenticando...</div>;


### PR DESCRIPTION
## Summary
- send access token and ORCID ID to backend
- store JWT returned from backend

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b0f240c48321a5494af1b78b1e81