### PR TITLE
Fix ORCID login scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Essas variáveis são utilizadas pelo `frontend-RCEI` durante o desenvolvimento 
 
 ### Escopos ORCID
 
-Para que a aplicação possa consultar publicações, financiamentos e revisões de pares,
-o token obtido no login precisa incluir ao menos o escopo `/read-public`.
-Caso deseje acessar informações restritas do perfil utilize também o escopo
+Para realizar o login e consultar publicações, financiamentos e revisões de pares,
+solicite o escopo `/authenticate` juntamente com `/read-public`.
+Se precisar acessar informações restritas do perfil inclua também o escopo
 `/read-limited`.

--- a/frontend-RCEI/src/pages/Login.tsx
+++ b/frontend-RCEI/src/pages/Login.tsx
@@ -65,8 +65,14 @@ export default function LoginPage() {
   };
 
   const handleOrcidLogin = () => {
-    const url = `https://orcid.org/oauth/authorize?client_id=${VITE_ORCID_CLIENT_ID}&response_type=code&scope=/read-public&redirect_uri=${encodeURIComponent(VITE_ORCID_REDIRECT_URI)}`;
-    window.location.href = url;
+    const params = new URLSearchParams({
+      client_id: VITE_ORCID_CLIENT_ID,
+      response_type: "code",
+      scope: "/authenticate /read-public",
+      redirect_uri: VITE_ORCID_REDIRECT_URI,
+    });
+
+    window.location.assign(`https://orcid.org/oauth/authorize?${params.toString()}`);
   };
 
 


### PR DESCRIPTION
## Summary
- update login URL builder to include `/authenticate` scope
- document required ORCID scopes for login

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855bdcbf178832183c555d0861513f7