### PR TITLE
Fix ORCID login URL encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ Essas variáveis são utilizadas pelo `frontend-RCEI` durante o desenvolvimento 
 
 ### Escopos ORCID
 
-Para que a aplicação possa consultar publicações, financiamentos e revisões de pares,
-o token obtido no login precisa incluir ao menos o escopo `/read-public`.
-Caso deseje acessar informações restritas do perfil utilize também o escopo
+Para realizar o login e consultar publicações, financiamentos e revisões de pares,
+solicite o escopo `/authenticate` juntamente com `/read-public`.
+Separe os escopos por espaço no parâmetro `scope`.
+Se precisar acessar informações restritas do perfil inclua também o escopo
 `/read-limited`.

--- a/frontend-RCEI/src/pages/Login.tsx
+++ b/frontend-RCEI/src/pages/Login.tsx
@@ -65,7 +65,12 @@ export default function LoginPage() {
   };
 
   const handleOrcidLogin = () => {
-    const url = `https://orcid.org/oauth/authorize?client_id=${VITE_ORCID_CLIENT_ID}&response_type=code&scope=/read-public&redirect_uri=${encodeURIComponent(VITE_ORCID_REDIRECT_URI)}`;
+    const url = `https://orcid.org/oauth/authorize?client_id=${encodeURIComponent(
+      VITE_ORCID_CLIENT_ID
+    )}&response_type=code&scope=${encodeURIComponent(
+      "/authenticate /read-public"
+    )}&redirect_uri=${encodeURIComponent(VITE_ORCID_REDIRECT_URI)}`;
+
     window.location.href = url;
   };
 


### PR DESCRIPTION
## Summary
- encode ORCID login parameters with `encodeURIComponent`
- clarify README on separating ORCID scopes

## Testing
- `npm test` *(fails: package.json not found)*
- `npm run lint` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855bdcbf178832183c555d0861513f7