### PR TITLE
Implement tag filters on search page

### DIFF
--- a/frontend-RCEI/src/pages/__tests__/Search.test.tsx
+++ b/frontend-RCEI/src/pages/__tests__/Search.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Search from '../Search';
@@ -28,5 +28,30 @@ describe('Search page', () => {
 
     await screen.findByText('John Doe');
     expect(orcidService.searchResearchers).toHaveBeenCalledWith('example');
+  });
+
+  it('searches when a tag is clicked', async () => {
+    (orcidService.searchResearchers as unknown as vi.Mock).mockResolvedValue({
+      "expanded-result": [],
+    });
+
+    const client = new QueryClient();
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/search']}>
+          <Routes>
+            <Route path="/search" element={<Search />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const tag = screen.getByText('Data Mining');
+    fireEvent.click(tag);
+
+    expect(orcidService.searchResearchers).toHaveBeenLastCalledWith(
+      'keyword:"Data Mining"'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add tag data and state to track active filters
- compose ORCID query with selected tags
- trigger searches whenever tags are toggled
- style tags to reflect active state
- test tag filter interaction

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576f013e508321a7c94dff1a357a08