### PR TITLE
Add project search endpoint and UI

### DIFF
--- a/frontend-RCEI/src/__tests__/Search.test.tsx
+++ b/frontend-RCEI/src/__tests__/Search.test.tsx
@@ -8,8 +8,9 @@ describe('Search filtering', () => {
   it('updates results when filter changes', () => {
     render(<Search />);
 
-    // Publications tab count should start at 0 because no data
+    // Publications and Projects tab counts should start at 0 because no data
     expect(screen.getByText(/Publicações \(0\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Projetos \(0\)/)).toBeInTheDocument();
 
     // Change filter to publications
     fireEvent.change(screen.getByRole('combobox'), {

--- a/frontend-RCEI/src/services/orcid.ts
+++ b/frontend-RCEI/src/services/orcid.ts
@@ -27,6 +27,21 @@ export async function searchResearchers(query: string) {
   return response.json();
 }
 
+export async function searchProjects(query: string) {
+  const token = getOrcidToken();
+  const headers: HeadersInit = { Accept: 'application/json' };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(
+    `https://pub.orcid.org/v3.0/expanded-search/?q=${encodeURIComponent(query)}&defType=dismax&search_field=funding`,
+    { headers },
+  );
+
+  return response.json();
+}
+
 export async function getWorks(orcid: string) {
   return fetchOrcid(`/${orcid}/works`);
 }


### PR DESCRIPTION
## Summary
- support searching ORCID funding via new `searchProjects` service
- fetch projects when search filter is set to projects
- show project results with counts
- update search test to check project tab

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576f0a8cc083218c3dc854a4dcb04d