### PR TITLE
Add backend tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,23 @@
+name: Backend Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend-RCEI
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend-RCEI/package-lock.json
+      - run: npm ci
+      - run: npm test

--- a/backend-RCEI/package.json
+++ b/backend-RCEI/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest"
   },
   "keywords": [],
   "author": "",
@@ -20,5 +20,9 @@
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.17.0",
     "mongoose": "^8.16.0"
+  },
+  "devDependencies": {
+    "supertest": "^6.3.4",
+    "vitest": "^1.5.2"
   }
 }

--- a/backend-RCEI/tests/orcidRoutes.test.js
+++ b/backend-RCEI/tests/orcidRoutes.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import orcidRoutes from '../routes/orcidRoutes';
+import axios from 'axios';
+
+vi.mock('axios');
+
+const app = express();
+app.use(express.json());
+app.use('/api', orcidRoutes);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.ORCID_CLIENT_ID = 'id';
+  process.env.ORCID_CLIENT_SECRET = 'secret';
+  process.env.ORCID_API_BASE_URL = 'https://example.com';
+});
+
+describe('GET /api/fundings', () => {
+  it('requires orcidId', async () => {
+    const res = await request(app).get('/api/fundings');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns data with valid orcidId', async () => {
+    axios.post.mockResolvedValue({ data: { access_token: 't' } });
+    axios.get.mockResolvedValue({ data: { foo: 'bar' } });
+    const res = await request(app).get('/api/fundings?orcidId=123');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ foo: 'bar' });
+  });
+});

--- a/backend-RCEI/tests/searchController.test.js
+++ b/backend-RCEI/tests/searchController.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { searchOrcidProfiles } from '../controllers/searchController';
+import axios from 'axios';
+
+vi.mock('axios');
+
+function mockResponse() {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.ORCID_CLIENT_ID = 'id';
+  process.env.ORCID_CLIENT_SECRET = 'secret';
+  process.env.ORCID_API_BASE_URL = 'https://example.com';
+});
+
+describe('searchOrcidProfiles', () => {
+  it('returns 400 when query is missing', async () => {
+    const req = { query: {} };
+    const res = mockResponse();
+    await searchOrcidProfiles(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns results when query is provided', async () => {
+    axios.post.mockResolvedValue({ data: { access_token: 'token' } });
+    axios.get.mockResolvedValue({ data: { ok: true } });
+
+    const req = { query: { query: 'john' } };
+    const res = mockResponse();
+    await searchOrcidProfiles(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add test runner and supertest dependencies
- configure backend tests workflow
- add search controller test
- add ORCID route test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b01ee5df8832180e455c4ba6d4528